### PR TITLE
Tag/Multiselect Edit feature with option to enable/disable this feature

### DIFF
--- a/BForms.Docs/Scripts/BForms/Plugins/Select2/js/select2.js
+++ b/BForms.Docs/Scripts/BForms/Plugins/Select2/js/select2.js
@@ -2660,7 +2660,32 @@ the specific language governing permissions and limitations under the Apache Lic
             this.container.on("click", selector, this.bind(function (e) {
                 if (!this.isInterfaceEnabled()) return;
                 if ($(e.target).closest(".select2-search-choice").length > 0) {
-                    // clicked inside a select2 search choice, do not open
+                    
+                    if (this.opts.editOnClick) {
+                        // clicked inside a select2 search choice, replace selected with text so it can be edited
+                        
+                        var selectedText = $(e.target).text();
+
+                        //remove selected value
+                        var isMsie = typeof $.browser !== "undefined" && $.browser.msie;
+
+                        if (isMsie) {
+                            $(e.target).closest(".select2-search-choice").hide();
+                            this.unselect($(e.target));
+                            this.open();
+                            this.focusSearch();
+                        } else {
+                            $(e.target).closest(".select2-search-choice").fadeOut('fast', this.bind(function() {
+                                this.unselect($(e.target));
+                                this.open();
+                                this.focusSearch();
+                            })).dequeue();
+                        }
+
+                        selection.find(".select2-search-field input").val(selectedText);
+                        this.resizeSearch();
+                    }
+                    
                     return;
                 }
                 this.selectChoice(null);
@@ -3237,6 +3262,7 @@ the specific language governing permissions and limitations under the Apache Lic
         loadMorePadding: 0,
         closeOnSelect: true,
         openOnEnter: true,
+        editOnClick : false,
         containerCss: {},
         dropdownCss: {},
         containerCssClass: "custom_select",


### PR DESCRIPTION
Tag/Multiselect Edit feature with option to enable/disable this feature
How to use:
 @Html.BsSelectFor(m => m.Example,null
new Dictionary<string, object> { { "select2TagsOpts", new Dictionary<string, object> { { "editOnClick", true } } } })

True for editable/ False for readonly
