### PR TITLE
Property for Toolbar ButtonGroup to align right the dropdown

### DIFF
--- a/BForms/Grid/BsToolbarButtonGroup.cs
+++ b/BForms/Grid/BsToolbarButtonGroup.cs
@@ -17,6 +17,7 @@ namespace BForms.Grid
 
         internal string styleClasses;
 
+        internal bool alignRight = false;
 
         internal IDictionary<string, object> HtmlAttr
         {
@@ -57,7 +58,6 @@ namespace BForms.Grid
         public BsToolbarButtonGroup<TToolbar> DisplayName(string name)
         {
             this.name = name;
-
             return this;
         }
 
@@ -68,7 +68,16 @@ namespace BForms.Grid
         public BsToolbarButtonGroup<TToolbar> GlyphIcon(Glyphicon icon)
         {
             this.glyphIcon = icon;
+            return this;
+        }
 
+        /// <summary>
+        /// Sets dropdown align right
+        /// </summary>
+        /// <returns>BsToolbarAction</returns>
+        public BsToolbarButtonGroup<TToolbar> AlignRight()
+        {
+            this.alignRight = true;
             return this;
         }
 
@@ -116,6 +125,7 @@ namespace BForms.Grid
 
         internal string styleClasses;
 
+        internal bool alignRight = false;
 
         internal IDictionary<string, object> HtmlAttr
         {
@@ -157,7 +167,6 @@ namespace BForms.Grid
         public BsToolbarButtonGroup DisplayName(string name)
         {
             this.name = name;
-
             return this;
         }
 
@@ -168,7 +177,16 @@ namespace BForms.Grid
         public BsToolbarButtonGroup GlyphIcon(Glyphicon icon)
         {
             this.glyphIcon = icon;
+            return this;
+        }
 
+        /// <summary>
+        /// Sets dropdown align right
+        /// </summary>
+        /// <returns>BsToolbarAction</returns>
+        public BsToolbarButtonGroup AlignRight()
+        {
+            this.alignRight = true;
             return this;
         }
 

--- a/BForms/Renderers/BsToolbarButtonGroupRenderer.cs
+++ b/BForms/Renderers/BsToolbarButtonGroupRenderer.cs
@@ -40,8 +40,10 @@ namespace BForms.Renderers
 
             var containerList = new TagBuilder("ul");
             containerList.AddCssClass("dropdown-menu");
+            if (this.Builder.alignRight)
+                containerList.AddCssClass("pull-right");
             containerList.MergeAttribute("role", "menu");
-
+          
             foreach (var item in this.Builder.Actions)
             {
                 var defaultAction = item as BsToolbarAction<TToolbar>;
@@ -98,6 +100,8 @@ namespace BForms.Renderers
 
             var containerList = new TagBuilder("ul");
             containerList.AddCssClass("dropdown-menu");
+            if (this.Builder.alignRight)
+                containerList.AddCssClass("pull-right");
             containerList.MergeAttribute("role", "menu");
 
             foreach (var item in this.Builder.Actions)


### PR DESCRIPTION
Property .AlignRight();

Example:
var groupButton = toolbarAction.AddButtonGroup().AlignRight();
