### PR TITLE
added option to localize "Go top" button from pager; added option for custom pager -> data page selector

### DIFF
--- a/BForms.Docs/Scripts/BForms/Widgets/Grid/js/bforms.grid.js
+++ b/BForms.Docs/Scripts/BForms/Widgets/Grid/js/bforms.grid.js
@@ -61,6 +61,7 @@
         onRefresh: null,
         pagerSelector: '.bs-pager',
         pagerGoTopTitle: 'Go top',
+        pagerDataPageContainer: 'page',
 
         detailsSelector: '.bs-expand',
         detailsUrl: null,
@@ -129,7 +130,8 @@
         this.$pager = this.element.find(this.options.pagerSelector).bsPager({
             pagerUpdate: $.proxy(this._evOnPageChange, this),
             pagerGoTop: $.proxy(this._evOnPagerGoTop, this),
-            goTopTitle: this.options.pagerGoTopTitle
+            goTopTitle: this.options.pagerGoTopTitle,
+            dataPageContainer: this.options.pagerDataPageContainer
         });
 
         //set default page size

--- a/BForms.Docs/Scripts/BForms/Widgets/Grid/js/bforms.pager.js
+++ b/BForms.Docs/Scripts/BForms/Widgets/Grid/js/bforms.pager.js
@@ -11,6 +11,7 @@
     Pager.prototype.options = {
         pagesContainerSelector: '.bs-pages',
         pageSelector: 'a[data-page]',
+        dataPageContainer: 'page',
         pageSizeSelector: '.bs-perPage',
         currentPageSelector: 'active',
         disabledPageSelector: 'disabled',
@@ -30,7 +31,7 @@
 
     Pager.prototype._initElements = function () {
         if (typeof $(this.options.goTopButtonSelector) !== "undefined") {
-            $(this.options.goTopButtonSelector).attr('title',this.options.goTopTitle);
+            $(this.options.goTopButtonSelector).attr('title', this.options.goTopTitle);
         }
     };
 
@@ -57,7 +58,7 @@
         }
 
         this._trigger('pagerUpdate', e, {
-            page: $me.data('page'),
+            page: $me.data(this.options.dataPageContainer),
             pageSize: this.element.find(this.options.pageSizeSelector + '.selected').data('value')
         });
 

--- a/BForms.Docs/Scripts/Controllers/Demo/Contributors/contributors-index.js
+++ b/BForms.Docs/Scripts/Controllers/Demo/Contributors/contributors-index.js
@@ -32,7 +32,6 @@
             $toolbar: this.$toolbar,
             uniqueName: 'usersGrid',
             pagerUrl: this.options.pagerUrl,
-            pagerGoTopTitle: 'Go top',
             addValidation: function (data, response) {
                 if (data["New.FirstName"] == "Cristi Pufu") return false;
             },


### PR DESCRIPTION
Example of usage: 

   GRID

this.$grid.bsGrid({
            $toolbar: this.$toolbar,
            uniqueName: 'usersGrid',
            pagerUrl: this.options.pagerUrl,
            pagerGoTopTitle: 'My Custom go top title',
            pagerDataPageContainer:'customPageSelector',
   .......

  PAGER

Or directly on bsPager 

$(element).bsPager({
       dataPageContainer: 'customPageSelector',
       goTopTitle: 'My Custom go top title'
...

   HTML 

Example of html for custom pager :
...
 <li><a data-customPageSelector="1" href="#">«</a></li>
 <li><a data-customPageSelector="2" href="#">«</a></li>
...
