### PR TITLE
fix bulk actions html attributes

### DIFF
--- a/BForms/Grid/BsBulkAction.cs
+++ b/BForms/Grid/BsBulkAction.cs
@@ -18,6 +18,7 @@ namespace BForms.Grid
         internal string buttonClass;
         internal string title;
         internal Glyphicon? glyphIcon;
+        internal IDictionary<string, object> htmlAttributes;
         public BsBulkActionType? Type;
         internal bool ignore;
         internal string text;
@@ -55,6 +56,12 @@ namespace BForms.Grid
                     this.glyphIcon = Glyphicon.Trash;
                     break;
             }
+        }
+
+        public BsBulkAction HtmlAttributes(IDictionary<string, object> htmlAttributes)
+        {
+            this.htmlAttributes = htmlAttributes;
+            return this;
         }
 
         public BsBulkAction StyleClass(string buttonClass)

--- a/BForms/Renderers/BsBulkActionRenderer.cs
+++ b/BForms/Renderers/BsBulkActionRenderer.cs
@@ -22,6 +22,8 @@ namespace BForms.Renderers
         {
             var bulkButton = new TagBuilder("button");
 
+            bulkButton.MergeAttributes(this.Builder.htmlAttributes);
+
             if (!String.IsNullOrEmpty(this.Builder.buttonClass))
             {
                 bulkButton.AddCssClass(this.Builder.buttonClass);
@@ -43,9 +45,7 @@ namespace BForms.Renderers
             {
                 bulkButton.MergeAttribute("title", this.Builder.title);
             }
-
-            bulkButton.MergeAttributes(this.Builder.htmlAttributes);
-
+           
             bulkButton.InnerHtml += (this.Builder.glyphIcon.HasValue ? GetGlyphicon(this.Builder.glyphIcon.Value) + " " : "") + this.Builder.text;
 
             return bulkButton.ToString();


### PR DESCRIPTION
Problem description :
If you had  wanted to set a custom class to your bulk actions buttons with Html Attributes, it wouldn't have worked  because of MergeAttributes method from TagBuilder

MergeAttributes it only adds new attributes to the collection( current values are replaced only if replaceExisting is set to true). It doesn't perform any merging logic.
