### PR TITLE
hide popover on row check

### DIFF
--- a/BForms.Docs/Scripts/BForms/Widgets/Grid/js/bforms.grid.js
+++ b/BForms.Docs/Scripts/BForms/Widgets/Grid/js/bforms.grid.js
@@ -843,7 +843,10 @@
             this._hideResetGridButton();
         }
 
+        this._hidePopoverOnRowCheckChange(e);
     };
+
+
 
     Grid.prototype._showBulkActions = function ($buttons, $checkedRows) {
 
@@ -1182,6 +1185,24 @@
     //#endregion
 
     //#region helpers and dom
+    Grid.prototype._hidePopoverOnRowCheckChange = function (e) {
+        var $currentTarget = $(e.target);
+        var $openPopovers = $('.bs-hasInlineQuestion').filter(function (idx, elem) {
+            var $elem = $(elem),
+                popover = $elem.data('bs.popover');
+
+            if (typeof popover !== "undefined" && popover != null) {
+                var $tip = popover.$tip;
+                return $tip.is(':visible') && $elem[0] != $currentTarget[0] && $elem.find($currentTarget).length == 0 && $currentTarget[0] != $tip[0] && $tip.find($currentTarget).length == 0;
+            }
+
+            return false;
+
+        });
+
+        $openPopovers.bsInlineQuestion('toggle');
+    };
+
     Grid.prototype._showFilterIcon = function () {
         this.$filterIcon.show();
         this._showResetGridButton();


### PR DESCRIPTION
Problem step-by-step description:

Step 1 -  Check a single row and click on delete bulk action
Step 2 -  Popover is now opened
Step 3 -  With popover opened uncheck that row
Step 4 -  Popover remains opened without any selected rows
