### PR TITLE
Removed toolbar button group positioning constraint

### DIFF
--- a/BForms.Docs/Areas/Demo/Views/Contributors/Toolbar/_Toolbar.cshtml
+++ b/BForms.Docs/Areas/Demo/Views/Contributors/Toolbar/_Toolbar.cshtml
@@ -10,18 +10,20 @@
     .SetTheme(Html.GetTheme())
     .ConfigureActions(ca =>
     {
+        ca.AddButtonGroup(buttonGroup =>
+        {
+            buttonGroup.DisplayName("Options").GlyphIcon(Glyphicon.Cog);
 
-        var groupButton = ca.AddButtonGroup().DisplayName("Options").GlyphIcon(Glyphicon.Cog);
+            buttonGroup.Add(BsToolbarActionType.Order)
+               .Text(Resource.Order)
+               .Tab(x => Html.BsPartialPrefixed(y => y.Order, "Toolbar/_Order", x));
 
-        groupButton.Add(BsToolbarActionType.Order)
-           .Text(Resource.Order)
-           .Tab(x => Html.BsPartialPrefixed(y => y.Order, "Toolbar/_Order", x));
-
-        groupButton.AddActionLink()
-            .Text("User profile")
-            .GlyphIcon(Glyphicon.User)
-            .Action(Url.Action("Index", "UserProfile"));
-
+            buttonGroup.AddActionLink()
+               .Text("User profile")
+               .GlyphIcon(Glyphicon.User)
+               .Action(Url.Action("Index", "UserProfile"));
+        });
+        
         ca.Add(BsToolbarActionType.Add)
          .Text(Resource.Add)
          .Tab(x => Html.BsPartialPrefixed(y => y.New, "Toolbar/_New", x));

--- a/BForms/Grid/BsToolbarActionsFactory.cs
+++ b/BForms/Grid/BsToolbarActionsFactory.cs
@@ -95,6 +95,23 @@ namespace BForms.Grid
 
             return group;
         }
+
+        /// <summary>
+        /// Adds ButtonGroup to Toolbar, right after the last added toolbar action
+        /// </summary>
+        public BsToolbarActionsBaseFactory<TToolbar> AddButtonGroup(Action<BsToolbarButtonGroup<TToolbar>> action)
+        {
+            var buttonGroupWrapper = new BsToolbarButtonGroupAction<TToolbar>
+            {
+                ButtonGroup = new BsToolbarButtonGroup<TToolbar>(this.viewContext)
+            };
+
+            action(buttonGroupWrapper.ButtonGroup);
+
+            this.actions.Add(buttonGroupWrapper);
+
+            return this;
+        }
     }
 
     /// <summary>

--- a/BForms/Grid/BsToolbarButtonGroupAction.cs
+++ b/BForms/Grid/BsToolbarButtonGroupAction.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BForms.Grid
+{
+    class BsToolbarButtonGroupAction<TToolbar> : BsToolbarAction<TToolbar>
+    {
+        public BsToolbarButtonGroup<TToolbar> ButtonGroup { get; set; }
+    }
+}

--- a/BForms/Renderers/BsToolbarBaseRenderer.cs
+++ b/BForms/Renderers/BsToolbarBaseRenderer.cs
@@ -114,7 +114,16 @@ namespace BForms.Renderers
                         tabNr++;
                     }
 
-                    controlsBuilder.InnerHtml += action.ToString();
+                    if (action is BsToolbarButtonGroupAction<TToolbar>)
+                    {
+                        var buttonGroup = (action as BsToolbarButtonGroupAction<TToolbar>).ButtonGroup;
+
+                        controlsBuilder.InnerHtml += buttonGroup.ToString();
+                    }
+                    else
+                    {
+                        controlsBuilder.InnerHtml += action.ToString();
+                    }                    
                 }
 
                 controlsContainer.InnerHtml += controlsBuilder;


### PR DESCRIPTION
Button groups were always added at the end of the toolbar actions. Now,
they can be added anywhere within the actions
