### PR TITLE
BsGridRowModel.HasDetails hack removed

### DIFF
--- a/BForms/Models/BsGrid.cs
+++ b/BForms/Models/BsGrid.cs
@@ -53,22 +53,13 @@ namespace BForms.Models
     }
 
     public abstract class BsGridRowModel<TDetails> : BsItemModel
+        where TDetails : class
     {
-        private TDetails details;
+        public TDetails Details { get; set; }
 
-        public TDetails Details
+        internal bool HasDetails
         {
-            get
-            {
-                return this.details;
-            }
-            set
-            {
-                this.details = value;
-                this.HasDetails = true;
-            }
+            get { return Details != null; }
         }
-
-        internal bool HasDetails { get; set; }
     }
 }


### PR DESCRIPTION
Changed HasDetails member to return if Details is not null (restricted
TDetails to class) rather that return true if Details has been set to
anything including null.
