### PR TITLE
Fix rangePicker.js

### DIFF
--- a/BForms.Docs/Scripts/BForms/Plugins/Rangepicker/js/bforms.rangepicker.js
+++ b/BForms.Docs/Scripts/BForms/Plugins/Rangepicker/js/bforms.rangepicker.js
@@ -41,6 +41,10 @@
         this._hasInitialValue = this.$element.val() != '';
         this._initInitialValues(!this._hasInitialValue);
 
+        if (this.options.allowUnspecifiedValue) {
+            this._updateLabels();
+        }
+
         this._addHandlers();
 
         this.$element.data('bsNumberRangepicker', this);


### PR DESCRIPTION
Add placeholder if the range value is null and the option allowUnspecifiedValue is true
