### PR TITLE
Add reference to bforms-extensions

### DIFF
--- a/BForms.Docs/Views/Start/Form/Source/_References.cs.embed
+++ b/BForms.Docs/Views/Start/Form/Source/_References.cs.embed
@@ -1,5 +1,6 @@
 ﻿require([
 'bforms-validate-unobtrusive',
+'bforms-extensions',
 'bforms-initUI'
 ], function () {
 


### PR DESCRIPTION
parseForm() method defined at bforms-extensions module.
So, without this reference you will get "Type error: parseForm is not a function"
